### PR TITLE
add -lrt to solve undefined reference of clock_gettime in ev.c

### DIFF
--- a/build_arm.sh
+++ b/build_arm.sh
@@ -1,1 +1,1 @@
-arm-linux-gnueabi-gcc server.c cJSON.c jsonrpc-c.c -lev -lm -static -o lepd -I./arm-libev -L./arm-libev/
+arm-linux-gnueabi-gcc server.c cJSON.c jsonrpc-c.c -lev -lm -lrt -static -o lepd -I./arm-libev -L./arm-libev/


### PR DESCRIPTION
building arm lepd acts different in my PC, it fails without -lrt due to undefined reference of clock_gettime in libev. i guess its harmless to have it in the script. please merge , thanks.